### PR TITLE
Model reuse and decoding from PCM

### DIFF
--- a/examples/whisper/__init__.py
+++ b/examples/whisper/__init__.py
@@ -1,0 +1,2 @@
+from .whisper import WhisperModel, decode_pcm, decode_wav_file
+


### PR DESCRIPTION
Hi,

I'm building my own useful-transformers based TTS for my home use. This patch does the following and is essential to me

* Exposes `WhisperModel`, `decode_pcm`, `decode_wav_file` when useful_transformers is imported
* Adds `decode_pcm` to enable transcribing directly from data contained in a HTTP request, without writing to file
* Patch up WAV to prevent non 16KHz audio being used
